### PR TITLE
Sort timeline in ascending or descending order

### DIFF
--- a/twtxt/cli.py
+++ b/twtxt/cli.py
@@ -20,6 +20,7 @@ from twtxt.file import get_local_tweets, add_local_tweet
 from twtxt.helper import run_post_tweet_hook
 from twtxt.helper import style_tweet, style_source, style_source_with_status
 from twtxt.helper import validate_created_at, validate_text
+from twtxt.helper import sort_tweets
 from twtxt.http import get_remote_tweets, get_remote_status
 from twtxt.log import init_logging
 from twtxt.types import Tweet, Source
@@ -96,7 +97,9 @@ def timeline(ctx, pager, limit, twtfile):
         source = Source(ctx.obj["conf"].nick, file=twtfile)
         tweets.extend(get_local_tweets(source, limit))
 
-    tweets = sorted(tweets, reverse=True)[:limit]
+    timeline_dir = ctx.obj["conf"].timeline_sorting
+    tweets = sort_tweets(tweets, timeline_dir, limit)
+
     if not tweets:
         return
 

--- a/twtxt/config.py
+++ b/twtxt/config.py
@@ -106,6 +106,11 @@ class Config:
         cfg = self.open_config()
         return cfg.get("twtxt", "post_tweet_hook", fallback=None)
 
+    @property
+    def timeline_sorting(self):
+        cfg = self.open_config()
+        return cfg.get("twtxt", "timeline_sorting", fallback="descending")
+
     def add_source(self, source):
         cfg = self.open_config()
 

--- a/twtxt/helper.py
+++ b/twtxt/helper.py
@@ -68,3 +68,14 @@ def run_post_tweet_hook(hook, options):
         click.echo("✗ Invalid variables in post_tweet_hook.")
         return False
     subprocess.call(command, shell=True, stdout=subprocess.PIPE)
+
+def sort_tweets(tweets, direction, limit):
+    if direction == "descending":
+        return sorted(tweets, reverse=True)[:limit]
+    elif direction == "ascending":
+        if limit < len(tweets):
+            return sorted(tweets)[len(tweets) - limit:]
+        else:
+            return sorted(tweets)
+    else:
+        return None


### PR DESCRIPTION
Added support for specifying the direction in which timeline posts are
sorted.

The behaviour is controlled through the timeline_sorting configuration
option under [twtxt] in the config file. It can be ascending or
descending, and defaults to descending if no preference is specified.

The actual sorting is done after retrieving the entire list of tweets by
calling a helper function.

Signed-off-by: Weland Treebark <weland@blinkenshell.org>