### PR TITLE
Fix default argument evaluation

### DIFF
--- a/twtxt/types.py
+++ b/twtxt/types.py
@@ -16,11 +16,14 @@ import humanize
 
 
 class Tweet:
-    def __init__(self, text, created_at=datetime.now(tzlocal()), source=None):
+    def __init__(self, text, created_at=None, source=None):
         if text:
             self.text = text
         else:
             raise ValueError("empty text")
+
+        if created_at is None:
+            created_at = datetime.now(tzlocal())
 
         try:
             self.created_at = created_at.replace(microsecond=0)


### PR DESCRIPTION
The default arguments are evaluated when module is loaded the first time. If twtxt is used as a package in another tool all created tweets would have the same `created_at` value - if not passed.