### PR TITLE
Implement porcelain option for timeline command

### DIFF
--- a/twtxt/cli.py
+++ b/twtxt/cli.py
@@ -93,8 +93,10 @@ def tweet(ctx, created_at, twtfile, text):
               help="Sort timeline in descending order. (Default)")
 @click.option("--timeout", type=click.FLOAT,
               help="Maximum time requests are allowed to take. (Default: 5.0)")
+@click.option("--porcelain", is_flag=True,
+              help="Give the output in an easy-to-parse format for scripts.")
 @click.pass_context
-def timeline(ctx, pager, limit, twtfile, sorting, timeout):
+def timeline(ctx, pager, limit, twtfile, sorting, timeout, porcelain):
     """Retrieve your personal timeline."""
     sources = ctx.obj["conf"].following
     tweets = get_remote_tweets(sources, limit, timeout)
@@ -108,14 +110,15 @@ def timeline(ctx, pager, limit, twtfile, sorting, timeout):
     if not tweets:
         return
 
-    if pager:
-        click.echo_via_pager("\n\n".join(
-            (style_tweet(tweet) for tweet in tweets)))
+    if porcelain:
+        timeline_output = "\n".join(str(tweet) for tweet in tweets)
     else:
-        click.echo()
-        for tweet in tweets:
-            click.echo(style_tweet(tweet))
-            click.echo()
+        timeline_output = "\n\n".join(style_tweet(tweet) for tweet in tweets)
+
+    if pager:
+        click.echo_via_pager(timeline_output)
+    else:
+        click.echo(timeline_output)
 
 
 @cli.command()


### PR DESCRIPTION
This patch implements a porcelain option for the timeline command.
It's similar to the porcelain option of other cli tools like the one of `git status`.

```bash
$ twtxt timeline --porcelain
2016-02-07T11:39:38-08:00       Test
2016-02-07T11:40:51-08:00       Test2
2016-02-07T19:43:07+00:00       foobar
2016-02-07T11:43:43-08:00       foobar2
```

Refers #20 

What about the tab delimiter? Do you prefer another character? i.e. git just uses a space ...