### PR TITLE
Strip tweet before posting

### DIFF
--- a/twtxt/helper.py
+++ b/twtxt/helper.py
@@ -59,6 +59,7 @@ def validate_text(ctx, param, value):
         value = click.get_text_stream("stdin").read()
 
     if value:
+        value = value.strip()
         if len(value) > 140:
             click.confirm("✂ Warning: Tweet is longer than 140 characters. Are you sure?", abort=True)
         return value


### PR DESCRIPTION
Strip whitespaces from tweet message.
This is required for `stdin` to prevent trailing newline. However, I think it's a good idea to strip the tweet message anyway in any case - left and right ...