### PR TITLE
Use tox and integrate with travis and coveralls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 build
 dist
 venv
+.tox/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,9 @@ python:
   - "3.5"
 
 install:
-  - pip install --editable .
-  - pip install coveralls
-  - pip install pytest pytest-cov
+  - pip install tox && pip install tox-travis
 
-script: make test
+script: tox
 
 after_success:
   coveralls

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-cov
+coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,36 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py34,py35
+
+[tox:travis]
+3.4 = py34-travis
+3.5 = py35-travis
+
+# testenv for local testing
+[testenv]
+usedevelop = true
+commands =
+    py.test --tb=short -v --cov twtxt/ tests/
+deps = -rdev-requirements.txt
+
+# pass extra information for proper travis build
+[testenv:py34-travis]
+usedevelop = true
+passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
+commands =
+    py.test --tb=short -v --cov twtxt/ tests/
+    coveralls
+deps = -rdev-requirements.txt
+
+[testenv:py35-travis]
+usedevelop = true
+passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
+commands =
+    py.test --tb=short -v --cov twtxt/ tests/
+    coveralls
+deps = -rdev-requirements.txt
+


### PR DESCRIPTION
Use tox for local and CI testing.

Run tox to run tests with python 3.4 and python 3.5:

```bash
tox
```

If tox is from a python version < 3.4.1 you have to call tox with this version:

```bash
python3.4 -m tox
```

This is needed because of the version check in *setup.py*.