### PR TITLE
support for a pre_tweet_hook configuration parameter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -125,6 +125,7 @@ Here’s an example ``conf`` file, showing every currently supported option:
     limit_timeline = 20
     timeout = 5.0
     sorting = descending
+    pre_tweet_hook = "scp buckket@example.org:~/public_html/twtxt.txt {twtfile}"
     post_tweet_hook = "scp {twtfile} buckket@example.org:~/public_html/twtxt.txt"
 
     [following]
@@ -151,10 +152,12 @@ Here’s an example ``conf`` file, showing every currently supported option:
 +-------------------+-------+------------+---------------------------------------------------+
 | sorting           | TEXT  | descending | sort timeline either descending or ascending      |
 +-------------------+-------+------------+---------------------------------------------------+
+| pre_tweet_hook    | TEXT  |            | command to be executed before tweeting            |
++-------------------+-------+------------+---------------------------------------------------+
 | post_tweet_hook   | TEXT  |            | command to be executed after tweeting             |
 +-------------------+-------+------------+---------------------------------------------------+
 
-``post_tweet_hook`` is very useful if you want to push your twtxt file to a remote (web) server. Check the example above tho see how it’s used with ``scp``.
+``pre_tweet_hook`` and ``post_tweet_hook`` are very useful if you want to push your twtxt file to a remote (web) server. Check the example above tho see how it’s used with ``scp``.
 
 [followings] section:
 =====================

--- a/config.example
+++ b/config.example
@@ -6,6 +6,7 @@ use_pager = False
 limit_timeline = 20
 timeout = 5.0
 sorting = descending
+pre_tweet_hook = "scp buckket@example.org:~/public_html/twtxt.txt {twtfile}"
 post_tweet_hook = "scp {twtfile} buckket@example.org:~/public_html/twtxt.txt"
 
 [following]

--- a/twtxt/config.py
+++ b/twtxt/config.py
@@ -102,6 +102,11 @@ class Config:
         return cfg.get("twtxt", "nick", fallback=os.environ.get("USER", ""))
 
     @property
+    def pre_tweet_hook(self):
+        cfg = self.open_config()
+        return cfg.get("twtxt", "pre_tweet_hook", fallback=None)
+
+    @property
     def post_tweet_hook(self):
         cfg = self.open_config()
         return cfg.get("twtxt", "post_tweet_hook", fallback=None)

--- a/twtxt/helper.py
+++ b/twtxt/helper.py
@@ -66,6 +66,14 @@ def validate_text(ctx, param, value):
         raise click.BadArgumentUsage("Text can’t be empty.")
 
 
+def run_pre_tweet_hook(hook, options):
+    try:
+        command = shlex.split(hook.format(**options))
+    except KeyError:
+        click.echo("✗ Invalid variables in pre_tweet_hook.")
+        return False
+    return not subprocess.call(command, shell=True, stdout=subprocess.PIPE)
+
 def run_post_tweet_hook(hook, options):
     try:
         command = shlex.split(hook.format(**options))


### PR DESCRIPTION
The motivation behind this is that I have 2 laptops which I use frequently, so I'd want to do something like `s3cmd get <remote-file>` to grab the latest official version of my stream before writing and re-uploading. You could also do this with a git repo and have the hook do a `git pull` or whatever (which is what I may end up doing, but for now I'm using an "s3" bucket)

This is 90% done. The remaining 10% I need help with, as I'm not familiar with Click or with python in general.

I want to abort execution if the pre_tweet_hook fails, so we don't end up uploading a stale file (which happened while I was testing this, oops!) but I'm not certain how best to do it. I tried raising a `click.UsageError` but that didn't seem correct. `click.Abort` just prints out "Aborted!" and exits, but doesn't say anything useful. The other [click exceptions](http://click.pocoo.org/6/api/#exceptions) don't seem to be relevant, and raising an `Exception` (which is what I currently have it doing) horks up a stack trace and some not-very-friendly text.