### PR TITLE
Make package executable when using python -m

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     ],
 
     entry_points={
-        'console_scripts': ['twtxt=twtxt.cli:main']
+        'console_scripts': ['twtxt=twtxt.__main__:main']
     },
 
     description='Decentralised, minimalist microblogging service for hackers.',

--- a/twtxt/__main__.py
+++ b/twtxt/__main__.py
@@ -236,4 +236,4 @@ main = cli
 
 if __name__ == "__main__":
     # execute only if run as a script
-    cli()
+    main()


### PR DESCRIPTION
Support executing the twtxt package. This becomes very handy when using multiple python versions and in virtualenvs:

```
python -m twtxt
python3.4 -m twtxt
python3.5 -m twtxt
```