### PR TITLE
Use tox in make test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
   - pip install coveralls
   - pip install pytest pytest-cov
 
-script: make test
+script: py.test --tb=short -v --cov twtxt/ tests/
 
 after_success:
   coveralls

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 test:
 	@echo "---> running tests"
-	@py.test --tb=short -v --cov twtxt/ tests/
+	@python -m tox


### PR DESCRIPTION
I would like to run `make test` locally to test against all supported python versions.

- Use tox inside Makefile
- Use pytest directly for travis