### PR TITLE
Support --since option for timeline and view cli command

### DIFF
--- a/docs/user/usage.rst
+++ b/docs/user/usage.rst
@@ -52,6 +52,11 @@ View your timeline
     ➤ alice (2 hours ago):
     I wonder if this is a thing?
 
+    $ twtxt timeline --since "10 minutes ago"
+
+    ➤ bob (5 minutes ago):
+    This is my first "tweet". :)
+
 View feed of specific source
 ----------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         'aiohttp',
         'python-dateutil',
         'humanize',
+        'dateparser',
         'click',
     ],
 

--- a/twtxt/cli.py
+++ b/twtxt/cli.py
@@ -20,7 +20,7 @@ from twtxt.config import Config
 from twtxt.helper import run_pre_tweet_hook, run_post_tweet_hook
 from twtxt.helper import sort_and_truncate_tweets
 from twtxt.helper import style_timeline, style_source, style_source_with_status
-from twtxt.helper import validate_created_at, validate_text, validate_config_key
+from twtxt.helper import validate_created_at, validate_text, validate_config_key, validate_human_datetime
 from twtxt.log import init_logging
 from twtxt.mentions import expand_mentions
 from twtxt.models import Tweet, Source
@@ -102,6 +102,8 @@ def tweet(ctx, created_at, twtfile, text):
               help="Sort timeline in ascending order.")
 @click.option("--descending", "sorting", flag_value="descending",
               help="Sort timeline in descending order. (Default)")
+@click.option("--since", callback=validate_human_datetime,
+              help="Show only tweets since a specific datetime")
 @click.option("--timeout", type=click.FLOAT,
               help="Maximum time requests are allowed to take. (Default: 5.0)")
 @click.option("--porcelain", is_flag=True,
@@ -112,7 +114,7 @@ def tweet(ctx, created_at, twtfile, text):
               is_flag=True,
               help="Cache remote twtxt files locally. (Default: True)")
 @click.pass_context
-def timeline(ctx, pager, limit, twtfile, sorting, timeout, porcelain, source, cache):
+def timeline(ctx, pager, limit, twtfile, sorting, since, timeout, porcelain, source, cache):
     """Retrieve your personal timeline."""
     if source:
         source_obj = ctx.obj["conf"].get_source_by_nick(source)
@@ -130,6 +132,9 @@ def timeline(ctx, pager, limit, twtfile, sorting, timeout, porcelain, source, ca
         tweets.extend(get_local_tweets(source, limit))
 
     tweets = sort_and_truncate_tweets(tweets, sorting, limit)
+
+    if since:
+        tweets = [t for t in tweets if t.created_at >= since]
 
     if not tweets:
         return
@@ -151,6 +156,8 @@ def timeline(ctx, pager, limit, twtfile, sorting, timeout, porcelain, source, ca
               help="Sort timeline in ascending order.")
 @click.option("--descending", "sorting", flag_value="descending",
               help="Sort timeline in descending order. (Default)")
+@click.option("--since", callback=validate_human_datetime,
+              help="Show only tweets since a specific datetime")
 @click.option("--timeout", type=click.FLOAT,
               help="Maximum time requests are allowed to take. (Default: 5.0)")
 @click.option("--porcelain", is_flag=True,

--- a/twtxt/helper.py
+++ b/twtxt/helper.py
@@ -12,12 +12,12 @@ import shlex
 import subprocess
 import sys
 import textwrap
-
 import click
 import pkg_resources
+import dateparser
 
 from twtxt.mentions import format_mentions
-from twtxt.parser import parse_iso8601
+from twtxt.parser import parse_iso8601, make_aware
 
 
 def style_timeline(tweets, porcelain=False):
@@ -112,6 +112,20 @@ def validate_config_key(ctx, param, value):
         raise click.BadArgumentUsage("Given key does not contain a section name.")
     else:
         return section, item
+
+
+def validate_human_datetime(ctx, param, value):
+    """Validate a human readable datetime"""
+    if not value:
+        return value
+
+    try:
+        parsed = dateparser.parse(value)
+        if not parsed:
+            raise ValueError
+        return make_aware(parsed)
+    except ValueError:
+        raise click.BadParameter("Cannot parse date time: '{0}'".format(value))
 
 
 def run_pre_tweet_hook(hook, options):


### PR DESCRIPTION
Support `--since` option in timeline and view cli command.
The `dateparser` package is used to parse the *since date*: https://pypi.python.org/pypi/dateparser

Examples:

```
twtxt timeline --since yesterday
twtxt timeline --since "1 hour ago"
twtxt view --since "Fri, 12 Dec 2014 10:55:50"
```