### PR TITLE
Add config CLI command to edit twtxt config file

### DIFF
--- a/docs/user/usage.rst
+++ b/docs/user/usage.rst
@@ -68,3 +68,15 @@ View feed of specific source
 
     ➤ http://example.org/twtxt.txt (a day ago):
     Fiat Lux!
+
+Edit twtxt configuration
+------------------------
+
+.. code::
+
+    $ twtxt config twtxt.nick tuxtimo
+    $ twtxt config twtxt.nick
+    tuxtimo
+    $ twtxt config --remove twtxt.nick
+    $ twtxt config --edit
+    # opens your sensible-editor to edit the config file

--- a/twtxt/cli.py
+++ b/twtxt/cli.py
@@ -20,7 +20,7 @@ from twtxt.config import Config
 from twtxt.helper import run_pre_tweet_hook, run_post_tweet_hook
 from twtxt.helper import sort_and_truncate_tweets
 from twtxt.helper import style_timeline, style_source, style_source_with_status
-from twtxt.helper import validate_created_at, validate_text
+from twtxt.helper import validate_created_at, validate_text, validate_config_key
 from twtxt.log import init_logging
 from twtxt.mentions import expand_mentions
 from twtxt.models import Tweet, Source
@@ -264,5 +264,44 @@ def quickstart():
     click.echo()
     click.echo("✓ Created config file at '{0}'.".format(click.format_filename(conf.config_file)))
 
+
+@cli.command()
+@click.argument("key", required=False, callback=validate_config_key)
+@click.argument("value", required=False)
+@click.option("--remove", flag_value=True,
+              help="Remove given item")
+@click.option("--edit", "-e", flag_value=True,
+              help="Open config file in editor")
+@click.pass_context
+def config(ctx, key, value, remove, edit):
+    """Get or Set config item"""
+    conf = ctx.obj["conf"]
+    if not edit and not key:
+        raise click.BadArgumentUsage("You have to specify either a key or --edit")
+
+    if edit:
+        return click.edit(filename=conf.config_file)
+
+    if remove:
+        try:
+            conf.cfg.remove_option(key[0], key[1])
+        except:
+            pass
+        else:
+            conf.write_config()
+        return
+
+    if not value:
+        try:
+            click.echo(conf.cfg.get(key[0], key[1]))
+        except:
+            pass
+        return
+
+    if not conf.cfg.has_section(key[0]):
+        conf.cfg.add_section(key[0])
+
+    conf.cfg.set(key[0], key[1], value)
+    conf.write_config()
 
 main = cli

--- a/twtxt/helper.py
+++ b/twtxt/helper.py
@@ -100,6 +100,19 @@ def validate_text(ctx, param, value):
         raise click.BadArgumentUsage("Text can’t be empty.")
 
 
+def validate_config_key(ctx, param, value):
+    """Validate a configuration key according to section.item"""
+    if not value:
+        return value
+
+    try:
+        section, item = value.split(".", 1)
+    except ValueError:
+        raise click.BadArgumentUsage("key does not contain a section")
+    else:
+        return section, item
+
+
 def run_pre_tweet_hook(hook, options):
     try:
         command = shlex.split(hook.format(**options))


### PR DESCRIPTION
This command behaves similar to other `config` CLI commands
for example the one from git:

``` bash
$ twtxt config twtxt.nick tuxtimo  # set nick
$ twtxt config twtxt.nick  # get nick
tuxtimo
$ twtxt config --remove twtxt.nick  # remove nick
$ twtxt config --edit  # edit config file with editor
```