### PR TITLE
 Make use of absolute time configurable for timeline

### DIFF
--- a/config.example
+++ b/config.example
@@ -10,6 +10,7 @@ disclose_identity = False
 limit_timeline = 20
 timeout = 5.0
 sorting = descending
+use_abs_time = False
 pre_tweet_hook = "scp buckket@example.org:~/public_html/twtxt.txt {twtfile}"
 post_tweet_hook = "scp {twtfile} buckket@example.org:~/public_html/twtxt.txt"
 

--- a/docs/user/configuration.rst
+++ b/docs/user/configuration.rst
@@ -61,6 +61,8 @@ Here’s an example ``conf`` file, showing every currently supported option:
 +-------------------+-------+------------+---------------------------------------------------+
 | sorting           | TEXT  | descending | sort timeline either descending or ascending      |
 +-------------------+-------+------------+---------------------------------------------------+
+| use_abs_time      | BOOL  | False      | use absolute datetimes in your timeline           |
++-------------------+-------+------------+---------------------------------------------------+
 | pre_tweet_hook    | TEXT  |            | command to be executed before tweeting            |
 +-------------------+-------+------------+---------------------------------------------------+
 | post_tweet_hook   | TEXT  |            | command to be executed after tweeting             |

--- a/twtxt/config.py
+++ b/twtxt/config.py
@@ -150,6 +150,10 @@ class Config:
         return self.cfg.getint("twtxt", "limit_timeline", fallback=20)
 
     @property
+    def use_abs_time(self):
+        return self.cfg.getboolean("twtxt", "use_abs_time", fallback=False)
+
+    @property
     def timeout(self):
         return self.cfg.getfloat("twtxt", "timeout", fallback=5.0)
 

--- a/twtxt/helper.py
+++ b/twtxt/helper.py
@@ -40,10 +40,11 @@ def style_tweet(tweet, porcelain=False):
         styled_text = format_mentions(tweet.text)
         len_styling = len(styled_text) - len(click.unstyle(styled_text))
         final_text = textwrap.shorten(styled_text, limit + len_styling) if limit else styled_text
+        timestamp = tweet.absolute_datetime if conf.use_abs_time else tweet.relative_datetime
         return "➤ {nick} ({time}):\n{tweet}".format(
             nick=click.style(tweet.source.nick, bold=True),
             tweet=final_text,
-            time=click.style(tweet.relative_datetime, dim=True))
+            time=click.style(timestamp, dim=True))
 
 
 def style_source(source, porcelain=False):

--- a/twtxt/models.py
+++ b/twtxt/models.py
@@ -73,10 +73,15 @@ class Tweet:
 
     @property
     def relative_datetime(self):
-        """Human-readable relative time string."""
+        """Return human-readable relative time string."""
         now = datetime.now(timezone.utc)
         tense = "from now" if self.created_at > now else "ago"
         return "{0} {1}".format(humanize.naturaldelta(now - self.created_at), tense)
+
+    @property
+    def absolute_datetime(self):
+        """Return human-readable absolute time string."""
+        return self.created_at.strftime("%a, %d %b %Y %H:%M:%S")
 
 
 class Source:


### PR DESCRIPTION
Use an absolute datetime for tweet timestamp in timeline per default as suggested in #90 
Make relative timestamps configurable with `use_rel_datetime`.