### PR TITLE
Mention gitter in community section in docs and readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,7 @@ Check out the full documentation at: http://twtxt.readthedocs.org/en/latest/
 Community
 ---------
 
+- twtxt gitter chat: https://gitter.im/buckket/twtxt
 - twtxt IRC channel: **#twtxt** on `irc.freenode.net`_
 
 Contributions

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,6 +28,7 @@ User Guide
 Community
 ---------
 
+- twtxt gitter chat: https://gitter.im/buckket/twtxt
 - twtxt IRC channel: **#twtxt** on `irc.freenode.net`_
 
 API Reference


### PR DESCRIPTION
I really like to have the gitter alternative for IRC - even though I like IRC.
Sometimes it's just easier - specially if I'm not on my computer.
And not everyone has IRC and it's pretty easy for everyone with a github account to join the gitter chat.

The big advantages I see in gitter are the repository notifications, the references to Issues, PR, code, markdown, etc.

So at least - mention it ;)