### PR TITLE
WIP/preview, offline mode, timeline support

### DIFF
--- a/twtxt/cli.py
+++ b/twtxt/cli.py
@@ -111,8 +111,11 @@ def tweet(ctx, created_at, twtfile, text):
 @click.option("--cache/--no-cache",
               is_flag=True,
               help="Cache remote twtxt files locally. (Default: True)")
+@click.option("--offline/--no-offline",
+              is_flag=True,
+              help="Don't refresh cache.")
 @click.pass_context
-def timeline(ctx, pager, limit, twtfile, sorting, timeout, porcelain, source, cache):
+def timeline(ctx, pager, limit, twtfile, sorting, timeout, porcelain, source, cache, offline):
     """Retrieve your personal timeline."""
     if source:
         source_obj = ctx.obj["conf"].get_source_by_nick(source)
@@ -123,7 +126,10 @@ def timeline(ctx, pager, limit, twtfile, sorting, timeout, porcelain, source, ca
     else:
         sources = ctx.obj["conf"].following
 
-    tweets = get_remote_tweets(sources, limit, timeout, cache)
+    if ctx.obj["conf"].offline:
+        tweets = get_cached_tweets(sources, limit)
+    else:
+        tweets = get_remote_tweets(sources, limit, timeout, cache)
 
     if twtfile and not source:
         source = Source(ctx.obj["conf"].nick, ctx.obj["conf"].twturl, file=twtfile)

--- a/twtxt/cli.py
+++ b/twtxt/cli.py
@@ -25,7 +25,7 @@ from twtxt.log import init_logging
 from twtxt.mentions import expand_mentions
 from twtxt.models import Tweet, Source
 from twtxt.twfile import get_local_tweets, add_local_tweet
-from twtxt.twhttp import get_remote_tweets, get_remote_status
+from twtxt.twhttp import get_remote_tweets, get_remote_status, get_cached_tweets
 
 logger = logging.getLogger(__name__)
 

--- a/twtxt/config.py
+++ b/twtxt/config.py
@@ -230,6 +230,7 @@ class Config:
                 "sorting": self.sorting,
                 "porcelain": self.porcelain,
                 "twtfile": self.twtfile,
+                "offline": self.offline,
             },
             "view": {
                 "pager": self.use_pager,

--- a/twtxt/config.py
+++ b/twtxt/config.py
@@ -140,6 +140,10 @@ class Config:
         return self.cfg.getboolean("twtxt", "use_cache", fallback=True)
 
     @property
+    def offline(self):
+        return self.cfg.getboolean("twtxt", "offline", fallback=False)
+
+    @property
     def porcelain(self):
         return self.cfg.getboolean("twtxt", "porcelain", fallback=False)
 

--- a/twtxt/twhttp.py
+++ b/twtxt/twhttp.py
@@ -123,6 +123,15 @@ def get_remote_tweets(sources, limit=None, timeout=5.0, use_cache=True):
     return tweets
 
 
+def get_cached_tweets(sources, limit=None):
+    cache = Cache.discover()
+    tweets = []
+    for source in sources:
+        tweets += cache.get_tweets(source.url, limit)
+
+    return tweets
+
+
 def get_remote_status(sources, timeout=5.0):
     conn = aiohttp.TCPConnector(conn_timeout=timeout, use_dns_cache=True)
     headers = generate_user_agent()


### PR DESCRIPTION
The timeline command fetches all updates each time, this can be pointless (if too frequent) or unwanted.
* with a synchronized config, one can copy just the cache file and timeline --offline
* with increased number of followers fetching updates takes time, separating fetching and viewing improves interactivity

The tests are missing etc, this is to gather ideas if this is the right approach.