### PR TITLE
Simplify `date` command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Features
 - A beautiful command-line interface thanks to click.
 - Asynchronous HTTP requests thanks to asyncio/aiohttp and Python 3.
 - Integrates well with existing tools (scp, cut, echo, date, etc.) and your shell.
-- Don’t like the official client? Tweet using ``echo -e "`date +%FT%T%:z`\tHello world!" >> twtxt.txt``!
+- Don’t like the official client? Tweet using ``echo -e "`date -Isecond`\tHello world!" >> twtxt.txt``!
 
 Documentation
 -------------


### PR DESCRIPTION
I believe `date +%FT%T%:z` is exactly the same as writing `date -Isecond`, just more complicated. They are both the same format, and you can run them at the same time and get the exact same result.

Relevant section of `man date`:

           -I[FMT], --iso-8601[=FMT]
                  output date/time in ISO 8601 format.  FMT='date' for  date  only
                  (the  default),  'hours', 'minutes', 'seconds', or 'ns' for date
                  and    time    to    the    indicated    precision.     Example:
                  2006-08-14T02:34:56-0600