### PR TITLE
Add missing cache_interval argument

### DIFF
--- a/twtxt/cli.py
+++ b/twtxt/cli.py
@@ -258,7 +258,7 @@ def unfollow(ctx, nick):
     source = ctx.obj['conf'].get_source_by_nick(nick)
 
     try:
-        with Cache.discover() as cache:
+        with Cache.discover(update_interval=ctx.obj["conf"].timeline_update_interval) as cache:
             cache.remove_tweets(source.url)
     except OSError as e:
         logger.debug(e)


### PR DESCRIPTION
The missing `cache_interval` argument causes an exception when attempting to unfollow a user, as per #141. This PR should fix that.