### PR TITLE
bugfix: don't assume that status has status_code

### DIFF
--- a/twtxt/helper.py
+++ b/twtxt/helper.py
@@ -69,7 +69,7 @@ def style_source_with_status(source, status, porcelain=False):
             content_length=status.content_length,
             last_modified=status.last_modified)
     else:
-        if status.status_code == 200:
+        if hasattr(status, 'status_code') and status.status_code == 200:
             scolor, smessage = "green", str(status.status_code)
         elif status:
             scolor, smessage = "red", str(status.status_code)


### PR DESCRIPTION
A 'twtxt following' call can fail with the following stack trace:

Traceback (most recent call last):
  File "/home/marado/.local/bin/twtxt", line 10, in <module>
    sys.exit(main())
  File "/home/marado/.local/lib/python3.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/marado/.local/lib/python3.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/marado/.local/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/marado/.local/lib/python3.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/marado/.local/lib/python3.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/marado/.local/lib/python3.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/marado/.local/lib/python3.7/site-packages/twtxt/cli.py", line 218, in following
    click.echo(style_source_with_status(source, status, porcelain))
  File "/home/marado/.local/lib/python3.7/site-packages/twtxt/helper.py", line 72, in style_source_with_status
    if status.status_code == 200:
AttributeError: 'NoneType' object has no attribute 'status_code'

This happens because we're assuming that status has the property
status_code, instead of validating first if that is the case. This patch
fixes that.