### PR TITLE
Don't assume that HTTP status has last_modified

### DIFF
--- a/twtxt/twhttp.py
+++ b/twtxt/twhttp.py
@@ -43,10 +43,13 @@ class SourceResponse:
 
     @property
     def natural_last_modified(self):
-        last_modified = parsedate_to_datetime(self.last_modified)
-        now = datetime.now(timezone.utc)
-        tense = "from now" if last_modified > now else "ago"
-        return "{0} {1}".format(humanize.naturaldelta(now - last_modified), tense)
+        if self.last_modified is None:
+            return "?"
+        else:
+            last_modified = parsedate_to_datetime(self.last_modified)
+            now = datetime.now(timezone.utc)
+            tense = "from now" if last_modified > now else "ago"
+            return "{0} {1}".format(humanize.naturaldelta(now - last_modified), tense)
 
 
 @asyncio.coroutine


### PR DESCRIPTION
`twtxt following` can err out with the following stack trace:
```
Traceback (most recent call last):
  File "/home/marado/.local/bin/twtxt", line 10, in <module>
    sys.exit(main())
  File "/home/marado/.local/lib/python3.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/marado/.local/lib/python3.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/marado/.local/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/marado/.local/lib/python3.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/marado/.local/lib/python3.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/marado/.local/lib/python3.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/marado/.local/lib/python3.7/site-packages/twtxt/cli.py", line 218, in following
    click.echo(style_source_with_status(source, status, porcelain))
  File "/home/marado/.local/lib/python3.7/site-packages/twtxt/helper.py", line 83, in style_source_with_status
    last_modified=status.natural_last_modified)
  File "/home/marado/.local/lib/python3.7/site-packages/twtxt/twhttp.py", line 52, in natural_last_modified
    last_modified = parsedate_to_datetime(self.last_modified)
  File "/usr/lib/python3.7/email/utils.py", line 198, in parsedate_to_datetime
    *dtuple, tz = _parsedate_tz(data)
TypeError: cannot unpack non-iterable NoneType object
```
That happens because we are here assuming that the status object has a
last_modified attribute. This patch corrects the code by stopping
assuming that, and returns a visible '?' if no last update timestamp is
known.