### PR TITLE
Add support of Python 3.7+

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,6 +9,7 @@ Jan Schütze <jan.schuetze@exozet.com>
 Jeremy Kitchen <kitchen@kitchen.io>
 Matthew Brady <brady.matthew@gmail.com>
 Melvin Carvalho <melvincarvalho@gmail.com>
+Sergei Kolesnikov <sergei@kolesnikov.se>
 tedder <ted@timmons.me>
 teddydestodes <derkomtur@schattengang.net>
 Ted Timmons <ted@perljam.net>

--- a/setup.py
+++ b/setup.py
@@ -28,11 +28,13 @@ setup(
 
     platforms='any',
 
+    python_requires='>=3.7',
     install_requires=[
-        'aiohttp>=2.2.5,<3',
+        'aiohttp>=3.8.1,<4',
+        'nest_asyncio>=1.5.4,<2',
         'python-dateutil>=2.6.1,<3',
-        'humanize>=0.5.1,<1',
-        'click>=6.7,<7',
+        'humanize>=4.0.0,<5',
+        'click>=8.0.0,<9',
     ],
 
     extras_require={
@@ -56,8 +58,10 @@ setup(
     classifiers=[
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Operating System :: OS Independent',
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34, py35
+envlist = py37, py38, py39, py310
 
 [testenv]
 commands = py.test --tb=short -v --cov {envsitepackagesdir}/twtxt/ tests/

--- a/twtxt/cache.py
+++ b/twtxt/cache.py
@@ -22,7 +22,7 @@ class Cache:
     cache_dir = get_app_dir("twtxt")
     cache_name = "cache"
 
-    def __init__(self, cache_file, cache, update_interval):
+    def __init__(self, cache_file, cache, update_interval=0):
         """Initializes new :class:`Cache` object.
 
         :param str cache_file: full path to the loaded cache file.

--- a/twtxt/cli.py
+++ b/twtxt/cli.py
@@ -12,6 +12,7 @@ import logging
 import os
 import sys
 import textwrap
+import shutil
 from itertools import chain
 
 import click
@@ -280,7 +281,7 @@ def unfollow(ctx, nick):
 @cli.command()
 def quickstart():
     """Quickstart wizard for setting up twtxt."""
-    width = click.get_terminal_size()[0]
+    width = shutil.get_terminal_size()[0]
     width = width if width <= 79 else 79
 
     click.secho("twtxt - quickstart", fg="cyan")

--- a/twtxt/helper.py
+++ b/twtxt/helper.py
@@ -12,7 +12,9 @@ import shlex
 import subprocess
 import sys
 import textwrap
+from functools import wraps
 
+import asyncio
 import click
 import pkg_resources
 
@@ -69,7 +71,7 @@ def style_source_with_status(source, status, porcelain=False):
             content_length=status.content_length,
             last_modified=status.last_modified)
     else:
-        if status.status_code == 200:
+        if hasattr(status, "status_code") and status.status_code == 200:
             scolor, smessage = "green", str(status.status_code)
         elif status:
             scolor, smessage = "red", str(status.status_code)
@@ -177,3 +179,10 @@ def generate_user_agent():
         user_agent = "twtxt/{version}".format(version=version)
 
     return {"User-Agent": user_agent}
+
+def coro(f):
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        return asyncio.run(f(*args, **kwargs))
+
+    return wrapper

--- a/twtxt/models.py
+++ b/twtxt/models.py
@@ -75,8 +75,12 @@ class Tweet:
     def relative_datetime(self):
         """Return human-readable relative time string."""
         now = datetime.now(timezone.utc)
-        tense = "from now" if self.created_at > now else "ago"
-        return "{0} {1}".format(humanize.naturaldelta(now - self.created_at), tense)
+        created_at = self.created_at.astimezone(timezone.utc)
+
+        delta = humanize.naturaldelta(abs(created_at - now))
+        tense = "from now" if now < created_at else "ago"
+
+        return f"{delta} {tense}"
 
     @property
     def absolute_datetime(self):

--- a/twtxt/twhttp.py
+++ b/twtxt/twhttp.py
@@ -10,7 +10,9 @@
 
 import asyncio
 import logging
+import nest_asyncio
 from datetime import datetime, timezone
+from itertools import chain
 from email.utils import parsedate_to_datetime
 from ssl import CertificateError
 
@@ -22,7 +24,7 @@ from twtxt.helper import generate_user_agent
 from twtxt.parser import parse_tweets
 
 logger = logging.getLogger(__name__)
-
+nest_asyncio.apply()
 
 class SourceResponse:
     """A :class:`SourceResponse` contains information about a :class:`Source`’s HTTP request.
@@ -49,11 +51,10 @@ class SourceResponse:
         return "{0} {1}".format(humanize.naturaldelta(now - last_modified), tense)
 
 
-@asyncio.coroutine
-def retrieve_status(client, source):
+async def retrieve_status(client, source):
     status = None
     try:
-        response = yield from client.head(source.url)
+        response = await client.head(source.url)
         if response.headers.get("Content-Length"):
             content_length = response.headers.get("Content-Length")
         else:
@@ -61,7 +62,7 @@ def retrieve_status(client, source):
         status = SourceResponse(status_code=response.status,
                                 content_length=content_length,
                                 last_modified=response.headers.get("Last-Modified"))
-        yield from response.release()
+        await response.release()
     except CertificateError as e:
         click.echo("✗ SSL Certificate Error: The feed's ({0}) SSL certificate is untrusted. Try using HTTP, "
                    "or contact the feed's owner to report this issue.".format(source.url))
@@ -72,14 +73,13 @@ def retrieve_status(client, source):
         return source, status
 
 
-@asyncio.coroutine
-def retrieve_file(client, source, limit, cache):
+async def retrieve_file(client, source, limit, cache):
     is_cached = cache.is_cached(source.url) if cache else None
     headers = {"If-Modified-Since": cache.last_modified(source.url)} if is_cached else {}
 
     try:
-        response = yield from client.get(source.url, headers=headers)
-        content = yield from response.text()
+        response = await client.get(source.url, headers=headers)
+        content = await response.text()
     except Exception as e:
         if is_cached:
             logger.debug("{0}: {1} - using cached content".format(source.url, e))
@@ -120,44 +120,39 @@ def retrieve_file(client, source, limit, cache):
         return []
 
 
-@asyncio.coroutine
-def process_sources_for_status(client, sources):
-    g_status = []
-    coroutines = [retrieve_status(client, source) for source in sources]
-    for coroutine in asyncio.as_completed(coroutines):
-        status = yield from coroutine
-        g_status.append(status)
-    return sorted(g_status, key=lambda x: x[0].nick)
+async def process_sources_for_status(client, sources):
+    tasks = [retrieve_status(client, source) for source in sources]
+    statuses = await asyncio.gather(*tasks)
+
+    return sorted(statuses, key=lambda x: x[0].nick)
 
 
-@asyncio.coroutine
-def process_sources_for_file(client, sources, limit, cache=None):
-    g_tweets = []
-    coroutines = [retrieve_file(client, source, limit, cache) for source in sources]
-    for coroutine in asyncio.as_completed(coroutines):
-        tweets = yield from coroutine
-        g_tweets.extend(tweets)
-    return sorted(g_tweets, reverse=True)[:limit]
+async def process_sources_for_file(client, sources, limit, cache=None):
+    tasks = [retrieve_file(client, source, limit, cache) for source in sources]
+    tweets_by_source = await asyncio.gather(*tasks)
+
+    all_tweets = list(chain.from_iterable(tweets_by_source))
+
+    return sorted(all_tweets, reverse=True)[:limit]
 
 
-def get_remote_tweets(sources, limit=None, timeout=5.0, cache=None):
+async def get_remote_tweets(sources, limit=None, timeout=5.0, cache=None):
     conn = aiohttp.TCPConnector(use_dns_cache=True)
     headers = generate_user_agent()
-    with aiohttp.ClientSession(connector=conn, headers=headers, conn_timeout=timeout) as client:
+
+    async with aiohttp.ClientSession(connector=conn, headers=headers, conn_timeout=timeout) as client:
         loop = asyncio.get_event_loop()
-
-        def start_loop(client, sources, limit, cache=None):
-            return loop.run_until_complete(process_sources_for_file(client, sources, limit, cache))
-
-        tweets = start_loop(client, sources, limit, cache)
+        tweets = loop.run_until_complete(process_sources_for_file(client, sources, limit, cache))
 
     return tweets
 
 
-def get_remote_status(sources, timeout=5.0):
+async def get_remote_status(sources, timeout=5.0):
     conn = aiohttp.TCPConnector(use_dns_cache=True)
     headers = generate_user_agent()
-    with aiohttp.ClientSession(connector=conn, headers=headers, conn_timeout=timeout) as client:
+
+    async with aiohttp.ClientSession(connector=conn, headers=headers, conn_timeout=timeout) as client:
         loop = asyncio.get_event_loop()
         result = loop.run_until_complete(process_sources_for_status(client, sources))
+
     return result


### PR DESCRIPTION
**Problem:** Generator-based coroutines are deprecated and scheduled for removal in Python 3.11 ([docs](https://docs.python.org/3/library/asyncio-task.html#generator-based-coroutines)). Due to that, twtxt doesn't work with Python 3.7+.

**Solution:** I have changed gererator-based coroutines to async-def coroutines. Other dependencies have also been updated to current versions.
Important: breaking changes, won't work with Python 3.6 or lower.

Passed tests: https://github.com/win0err/twtxt/actions/runs/2009500872
I'll create a PR with integration with GitHub Actions in a separate PR.

Closes #140, closes #141, closes #161, closes #162, closes #163

P.S. Please, test the changes manually.