### PR TITLE
Convert all asyncio.coroutine functions to async defs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,6 @@ setup(
     classifiers=[
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Operating System :: OS Independent',
         'Development Status :: 5 - Production/Stable',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34, py35
+envlist = py35
 
 [testenv]
 commands = py.test --tb=short -v --cov {envsitepackagesdir}/twtxt/ tests/

--- a/twtxt/twhttp.py
+++ b/twtxt/twhttp.py
@@ -49,11 +49,10 @@ class SourceResponse:
         return "{0} {1}".format(humanize.naturaldelta(now - last_modified), tense)
 
 
-@asyncio.coroutine
-def retrieve_status(client, source):
+async def retrieve_status(client, source):
     status = None
     try:
-        response = yield from client.head(source.url)
+        response = await client.head(source.url)
         if response.headers.get("Content-Length"):
             content_length = response.headers.get("Content-Length")
         else:
@@ -61,7 +60,7 @@ def retrieve_status(client, source):
         status = SourceResponse(status_code=response.status,
                                 content_length=content_length,
                                 last_modified=response.headers.get("Last-Modified"))
-        yield from response.release()
+        await response.release()
     except CertificateError as e:
         click.echo("✗ SSL Certificate Error: The feed's ({0}) SSL certificate is untrusted. Try using HTTP, "
                    "or contact the feed's owner to report this issue.".format(source.url))
@@ -72,14 +71,13 @@ def retrieve_status(client, source):
         return source, status
 
 
-@asyncio.coroutine
-def retrieve_file(client, source, limit, cache):
+async def retrieve_file(client, source, limit, cache):
     is_cached = cache.is_cached(source.url) if cache else None
     headers = {"If-Modified-Since": cache.last_modified(source.url)} if is_cached else {}
 
     try:
-        response = yield from client.get(source.url, headers=headers)
-        content = yield from response.text()
+        response = await client.get(source.url, headers=headers)
+        content = await response.text()
     except Exception as e:
         if is_cached:
             logger.debug("{0}: {1} - using cached content".format(source.url, e))
@@ -120,44 +118,47 @@ def retrieve_file(client, source, limit, cache):
         return []
 
 
-@asyncio.coroutine
-def process_sources_for_status(client, sources):
+async def process_sources_for_status(client, sources):
     g_status = []
-    coroutines = [retrieve_status(client, source) for source in sources]
-    for coroutine in asyncio.as_completed(coroutines):
-        status = yield from coroutine
+    for source in sources:
+        status = await retrieve_status(client, source)
         g_status.append(status)
     return sorted(g_status, key=lambda x: x[0].nick)
 
 
-@asyncio.coroutine
-def process_sources_for_file(client, sources, limit, cache=None):
+async def process_sources_for_file(client, sources, limit, cache=None):
     g_tweets = []
-    coroutines = [retrieve_file(client, source, limit, cache) for source in sources]
-    for coroutine in asyncio.as_completed(coroutines):
-        tweets = yield from coroutine
+    for source in sources:
+        tweets = await retrieve_file(client, source, limit, cache)
         g_tweets.extend(tweets)
     return sorted(g_tweets, reverse=True)[:limit]
 
 
 def get_remote_tweets(sources, limit=None, timeout=5.0, cache=None):
-    conn = aiohttp.TCPConnector(use_dns_cache=True)
-    headers = generate_user_agent()
-    with aiohttp.ClientSession(connector=conn, headers=headers, conn_timeout=timeout) as client:
-        loop = asyncio.get_event_loop()
+    async def start_loop():
+        conn = aiohttp.TCPConnector(use_dns_cache=True)
+        headers = generate_user_agent()
 
-        def start_loop(client, sources, limit, cache=None):
-            return loop.run_until_complete(process_sources_for_file(client, sources, limit, cache))
+        async with aiohttp.ClientSession(connector=conn, headers=headers, conn_timeout=timeout) as client:
 
-        tweets = start_loop(client, sources, limit, cache)
+            return await process_sources_for_file(client, sources, limit, cache)
+
+    loop = asyncio.get_event_loop()
+    tweets = loop.run_until_complete(start_loop())
 
     return tweets
 
 
 def get_remote_status(sources, timeout=5.0):
-    conn = aiohttp.TCPConnector(use_dns_cache=True)
-    headers = generate_user_agent()
-    with aiohttp.ClientSession(connector=conn, headers=headers, conn_timeout=timeout) as client:
-        loop = asyncio.get_event_loop()
-        result = loop.run_until_complete(process_sources_for_status(client, sources))
+    async def start_loop():
+        conn = aiohttp.TCPConnector(use_dns_cache=True)
+        headers = generate_user_agent()
+
+        async with aiohttp.ClientSession(connector=conn, headers=headers, conn_timeout=timeout) as client:
+            result = await process_sources_for_status(client, sources)
+
+        return result
+
+    loop = asyncio.get_event_loop()
+    result = loop.run_until_complete(start_loop())
     return result


### PR DESCRIPTION
This also removes Python 3.4 from `tox.ini` since `async def` is invalid before Python 3.5.

It would also probably solve #168 

Signed-off-by: Gergely Polonkai <gergely@polonkai.eu>