### PR TITLE
Link to getwtxt-ng registry server instead of deprecated getwtxt.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Contributions
 - A twtxt client written in C by `dertuxmalwieder <https://github.com/dertuxmalwieder>`_: https://hub.darcs.net/dertuxmalwieder/twtxtc
 - A read-only timeline of the last 3000 tweets via gopher by `trqx <gopher://shroom.party>`_: gopher://shroom.party/1/twtxt
 - A bot for using twtxt over xmpp by `mdosch <https://blog.mdosch.de>`_: https://salsa.debian.org/mdosch-guest/goxtxt
-- twtxt registry server written in Go by `gbmor <https://github.com/gbmor>`_: https://github.com/getwtxt/getwtxt
+- twtxt registry server written in Go by `gbmor <https://github.com/gbmor>`_: https://github.com/gbmor/getwtxt-ng
 - A twtxt parsing library written in Rust by `gbmor <https://github.com/gbmor>`_: https://github.com/rustwtxt/rustwtxt
 - A twtxt WordPress plugin, that provides the blog-posts as twtxt file, written by `pfefferle <https://github.com/pfefferle>`_: https://github.com/pfefferle/wordpress-twtxt
 - A twtxt client for Emacs by `deadblackclover <https://github.com/deadblackclover>`_: https://github.com/deadblackclover/twtxt-el


### PR DESCRIPTION
I rewrote my registry server from scratch to be a cleaner/simpler codebase and add a JSON API to complement the plain API from the spec. I'm just swapping the link out here. It still needs work but it's usable and less buggy than the old one.