### PR TITLE
README: we-are-twtxt moved on

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Community
 Contributions
 -------------
 
-- A curated list of active twtxt users by `mdom <https://github.com/mdom>`_: https://github.com/mdom/we-are-twtxt
+- A curated list of active twtxt users by `yarn.social <https://yarn.social/>`_: https://git.mills.io/yarnsocial/we-are-twtxt
 - A web-based directory of twtxt users by `reednj <https://twitter.com/reednj>`_: http://twtxt.reednj.com/
 - A web-based twtxt feed hoster for the masses by `plomlompom <http://www.plomlompom.de/>`_: https://github.com/plomlompom/htwtxt
 - A twtxt-to-atom converter in sh by `erlehmann <http://news.dieweltistgarnichtso.net/>`_: http://news.dieweltistgarnichtso.net/bin/twtxt2atom


### PR DESCRIPTION
The old mdom's `we-are-twtxt` repository is no longer available, but yarn.social kept maintaining a fork of it for a good while. It is currently archived, but still available on the address this commit changes the link to.

I'm not sure, but it might make more sense to just remove this enrtry altogether, since the list is no longer maintained and the link only points to an archive.