### PR TITLE
replace pkg_resources for python 3.12

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -15,7 +15,7 @@ jobs:
     
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         
     name: Testing using Python ${{ matrix.python-version }}
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
 
     platforms='any',
 
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     install_requires=[
         'aiohttp>=3.8.1,<4',
         'python-dateutil>=2.6.1,<3',
@@ -57,10 +57,11 @@ setup(
     classifiers=[
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Operating System :: OS Independent',
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py38, py39, py310
+envlist = py38, py39, py310, py311, py312
 
 [testenv]
 commands = py.test --tb=short -v --cov {envsitepackagesdir}/twtxt/ tests/

--- a/twtxt/helper.py
+++ b/twtxt/helper.py
@@ -14,7 +14,6 @@ import sys
 import textwrap
 
 import click
-import pkg_resources
 
 from twtxt.mentions import format_mentions
 from twtxt.parser import parse_iso8601
@@ -164,10 +163,7 @@ def sort_and_truncate_tweets(tweets, direction, limit):
 
 
 def generate_user_agent():
-    try:
-        version = pkg_resources.require("twtxt")[0].version
-    except pkg_resources.DistributionNotFound:
-        version = "unknown"
+    from twtxt import __version__ as version
 
     conf = click.get_current_context().obj["conf"]
     if conf.disclose_identity and conf.nick and conf.twturl:


### PR DESCRIPTION
Python 3.12 has removed bundled `setuptools` (aka `pkg_resources`): https://docs.python.org/3.12/whatsnew/3.12.html#removed

Also bumps to python 3.8+ (since 3.7 is unsupported)
